### PR TITLE
Add doctests for `boxerror_replacement`

### DIFF
--- a/src/boxerror_replacement.rs
+++ b/src/boxerror_replacement.rs
@@ -3,7 +3,9 @@
 //! This module introduces the `DynError` type, which owns an inner `Box<dyn Error>`. Most
 //! importantly, `DynError` _does_ implement the `Error` trait, unlike `Box<dyn Error>`. As a
 //! result, `DynError` is more conveniently compatible with the rest of the error handling
-//! ecosystem, and behaves as any other error type does. 
+//! ecosystem, and behaves just like any other error type does. 
+//!
+//! # Background
 //!
 //! The short answer as to why `Box<dyn Error>` doesn't implement `Error` is because there 
 //! exists a blanket implementation of the `Error` trait for `Box<T>`, more specifically: 
@@ -23,9 +25,31 @@
 //! constructed with `?` from arbitrary error types when paired with `DynResult`. Using a
 //! `Result<T, DynError>` will require manual conversion of error types due to it missing the
 //! `From` impl that is present on `Box<dyn Error>`. 
+//!
+//! # Examples
+//!
+//! `DynResult` is not quite a drop-in replacement for `Box<dyn Error>`. Some noticeable
+//! differences include the aforementioned requirement that any time we have a function that might
+//! result in a `DynResult`, that function must use the corresponding `DynResult` type as its
+//! return type.
+//!
+//! ```rust
+//! use trial_and_error::DynResult;
+//!
+//! fn main() -> DynResult<()> {
+//!     let _parsed = "4".parse::<u32>()?;
+//!
+//!     DynResult::Ok(())
+//! }
+//! ```
+//!
+//! Additionally, since `DynError` wraps a `BoxError` type, which is an alias for `Box<dyn Error +
+//! Send + Sync + 'static>`, any error handling API that requires type erased non-thread-safe
+//! errors would not be able to make use of `DynError`.
 
 use std::fmt;
 use std::error::Error;
+use std::convert::Infallible;
 
 type BoxError = Box<dyn Error + Send + Sync + 'static>;
 


### PR DESCRIPTION
Draft PR to start adding doctests to the Error Reporter and DynError modules.